### PR TITLE
Decouple dirs

### DIFF
--- a/manifests/common.pp
+++ b/manifests/common.pp
@@ -32,18 +32,52 @@
 # Sample Usage:
 #   include "pbuilder::common"
 #
-class pbuilder::common {
+class pbuilder::common(
+  $package   = $pbuilder::params::package,
+  $confdir   = $pbuilder::params::confdir,
+  $cachedir  = $pbuilder::params::cachedir,
+  $chrootdir = $pbuilder::params::chrootdir,
+  $group     = $pbuilder::params::group,
+) inherits pbuilder::params {
+  # validate parameters
+  validate_string($package)
+  validate_absolute_path($confdir)
+  validate_absolute_path($cachedir)
+  validate_absolute_path($chrootdir)
+  validate_string($group)
 
   # Call this class from within the pbuilder definition
 
-  package { 'pbuilder':
+  package { $package:
     ensure => installed,
   }
 
-  group { 'pbuilder':
+  group { $group:
     ensure => present,
     system => true,
   }
 
+  # The directories should be created by the package, but Puppet doesn't know that, so tell it.
+  file { $confdir:
+    ensure => directory,
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0755',
+  }
+
+  file { $cachedir:
+    ensure => directory,
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0755',
+  }
+
+  # Package does not create the chroot dir
+  file { $chrootdir:
+    ensure => directory,
+    owner  => 'root',
+    group  => $group,
+    mode   => '0755',
+  }
 }
 

--- a/manifests/cowbuilder.pp
+++ b/manifests/cowbuilder.pp
@@ -2,15 +2,15 @@ define pbuilder::cowbuilder (
   $ensure='present',
   $dist=$::lsbdistcodename,
   $arch=$::architecture,
-  $cachedir='/var/cache/pbuilder',
-  $confdir='/etc/pbuilder',
   $pbuilderrc=undef,
 ) {
 
   include ::pbuilder::cowbuilder::common
 
+  $cachedir   = ${::pbuilder::common::cachedir}
+  $confdir    = ${::pbuilder::common::confdir}
   $cowbuilder = '/usr/sbin/cowbuilder'
-  $basepath = "${cachedir}/base-${name}.cow"
+  $basepath   = "${cachedir}/base-${name}.cow"
 
   concat {"${confdir}/${name}/apt/preferences":
     owner   => root,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -36,7 +36,6 @@ define pbuilder(
   $methodurl    = undef,
   $debbuildopts = '-b',
   $bindmounts   = undef,
-  $bindir       = '/usr/local/bin',
   $rctemplate   = 'pbuilder/pbuilderrc.erb',
 ) {
 
@@ -47,6 +46,7 @@ define pbuilder(
 
   # directories
   $_chrootdir           = ${::pbuilder::common::chrootdir}
+  $bindir               = '/usr/local/bin'
   $pbuilder_confdir     = "${::pbuilder::common::confdir}/${name}"
   $pbuilder_cachedir    = "${::pbuilder::common::cachedir}/${name}"
   $builddir             = "${pbuilder_cachedir}/build"
@@ -76,14 +76,6 @@ define pbuilder(
         group   => 'root',
         mode    => '0755',
         recurse => true,
-      }
-
-      # LEGACY: ensure bindir exists
-      #  the file type can't do that yet
-      exec {
-        "bindir-${name}":
-          command => "/bin/mkdir -p ${bindir}",
-          creates => $bindir;
       }
 
       file {$script:

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -37,9 +37,9 @@ define pbuilder(
   $debbuildopts = '-b',
   $bindmounts   = undef,
   $bindir       = '/usr/local/bin',
-  $chrootdir    = '/var/chroot/pbuilder',
-  $confdir      = '/etc/pbuilder',
-  $cachedir     = '/var/cache/pbuilder',
+  $chrootdir    = $pbuilder::params::chrootdir,
+  $confdir      = $pbuilder::params::confdir,
+  $cachedir     = $pbuilder::params::cachedir,
   $rctemplate   = 'pbuilder/pbuilderrc.erb',
 ) {
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,0 +1,16 @@
+# default parameters as provided by the OS
+class pbuilder::params {
+
+  case $::osfamily {
+    'Debian': {
+      $package   = 'pbuilder'
+      $confdir   = '/etc/pbuilder'
+      $chrootdir = '/var/chroot/pbuilder'
+      $cachedir  = '/var/cache/pbuilder'
+      $group     = 'pbuilder'
+    }
+    default: {
+      fail( "Module ${module_name} is not supported on ${::osfamily} based system" )
+    }
+  }
+}


### PR DESCRIPTION
Hi,

I've come across a dependency ordering issue where some additional configuration (e.g. apt config, hooks etc.) needs to be setup before the pbuilder instance is instantiated (or at least before the create operation occurs) - but the directories don't exist. If I try to depend upon the resources cyclic dependencies result.

This is the first in a series of pull requests that intends to decouple the directory construction from the operations (create, update, remove) of a specific pbuilder instance. This request fixes the top-level directories (sacrificing _some_ flexibility) in order to move those constructs to the common.pp file.
The init.pp is then simplified somewhat. In addition the last commit forces the script directory to be /usr/local/bin as this is always available on any unix system.

This is incomplete and doesn't totally solve the problem I had but it demonstrates the direction I'm considering.

I'm happy to discuss further and not expecting it to be merged as is, any alternative suggestions gratefully appreciated.

Thanks,

Brett